### PR TITLE
package: Added "Dapper" package missing reference

### DIFF
--- a/Website/Website.csproj
+++ b/Website/Website.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />


### PR DESCRIPTION
The web projects was failing to build. It required the Dapper package that was missing.

Acceptance Criteria: ✅  Project should build and the web application should load. 

 